### PR TITLE
support use google cloud api to enhance translate quality

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "%noticeOnlyError.description%"
+                },
+                "google-translate.useGoogleCloudAPIs": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%useGoogleCloudAPIs.description%"
+                },
+                "google-translate.googleCloudAPIsKey": {
+                    "type": "string",
+                    "default": "Replace With Your Own Google Cloud APIs key",
+                    "description": "%googleCloudAPIsKey.description%"
                 }
             }
         }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -14,6 +14,8 @@
     "secondLanguage.description": "如果是第一语言，他将会被翻译成这个语言。",
     "maxSizeOfResult.description": "显示于状态栏与消息框的结果最大长度，超过这个长度将以省略号代替。",
     "noticeOnlyError.description": "减少消息框，只提醒错误消息。",
+    "useGoogleCloudAPIs.description": "使用Google Cloud APIs翻译，可以提高翻译质量。",
+    "googleCloudAPIsKey.description": "使用Google Cloud APIs翻译需要设置key，key申请参考https://cloud.google.com/docs/authentication/api-keys",
     "firstLanguage.default": "zh-cn",
     "translate.domain": "https://t.hancel.org"
 }

--- a/tranlate.js
+++ b/tranlate.js
@@ -1,0 +1,77 @@
+const vscode = require('vscode');
+const translator = require('@imlinhanchao/google-translate-api');
+
+let config = {};
+
+
+async function translate(text, lang) {
+    try{
+        let result = await translator(text, {
+            from: lang.from == 'auto' ? undefined : lang.from,
+            to: lang.to,
+            url: config['google-translate.serverDomain'].replace(/\/$/, ''),
+            useGoogleCloudAPIs: useGoogleCloudAPIs || config['google-translate.useGoogleCloudAPIs'],
+            googleCloudAPIsKey: googleCloudAPIsKey || config['google-translate.googleCloudAPIsKey'],
+        })
+
+        return {
+            lang,
+            text,
+            word: result.text || '',
+            candidate: result.candidates
+        };
+    } catch (err) {
+        throw new Error(`Translate failed, Error message: '${err.message}'. Please post an issues for me.`);
+    }      
+}
+
+function getConfig() {
+    let keys = [
+        'google-translate.switchFunctionTranslation',
+        'google-translate.serverDomain',
+        'google-translate.firstLanguage',
+        'google-translate.secondLanguage',
+        'google-translate.useGoogleCloudAPIs',
+        'google-translate.googleCloudAPIsKey',
+    ];
+
+    let values = {};
+    keys.forEach(k => values[k] = vscode.workspace.getConfiguration().get(k))
+    return values;
+}
+
+module.exports = async (word, l, from='auto') => {
+    if (word == '') return null;
+    config = getConfig();
+    let lang = {
+        from,
+        to: l || config['google-translate.firstLanguage']
+    };
+
+    if (config['google-translate.switchFunctionTranslation']) {
+        word = word.replace(/([a-z])([A-Z])/g, "$1 $2")
+            .replace(/([_])/g, " ").replace(/=/g, ' = ')
+            .replace(/(\b)\.(\b)/g, '$1 \n{>}\n $2 ');
+    }
+
+    let tran = await translate(word, lang);
+    if (tran.word.replace(/\s/g, '') == word.replace(/\s/g, '') || !tran.word.trim()) {
+        lang.to = config['google-translate.secondLanguage'];
+        let tranSecond = await translate(word, lang);
+        if (tranSecond.word) tran = tranSecond;
+    }
+
+    if (l && tran.word.replace(/\s/g, '') == word.replace(/\s/g, '')) {
+        lang.to = config['google-translate.firstLanguage'];
+        let tranSecond = await translate(word, lang);
+        if (tranSecond.word) tran = tranSecond;
+    }
+    if (config['google-translate.switchFunctionTranslation']) {
+        tran.word = tran.word.replace(/\n{>}\n/g, '.');
+        tran.candidate = tran.candidate.map(c => c.replace(/{([^>]*?)>}/g, '$1\n{>}').replace(/\n{>}\n/g, '.'));
+    }
+    return tran;
+};
+
+module.exports.getConfig = getConfig;
+module.exports.languages = translator.languages;


### PR DESCRIPTION
目前使用的api翻译质量较差，例如翻译“开车的迪迦奥特曼”，现在会翻译成“Diga Altman who drives”

现在支持使用Google Cloud API的翻译api，会正确的翻译成“Ultraman Tiga driving”

Google Cloud APIs key 申请参考 https://cloud.google.com/docs/authentication/api-keys